### PR TITLE
feat(process): add safe Windows CreateProcessW abstraction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ colored = "3.0.0"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
 crossterm = "0.28.1"
 sysinfo = "0.35.1"
-winapi = "0.3.9"
+winapi = { version = "0.3.9", features = ["consoleapi", "processthreadsapi", "handleapi", "winbase", "errhandlingapi", "winnt"] }
 windows-acl = "0.3.0"
 dirs = "5.0"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod process; 

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,0 +1,120 @@
+//! Safe abstraction over Windows CreateProcessW
+//!
+//! Provides process::spawn() for launching processes with robust error handling and resource management.
+
+use std::ffi::OsStr;
+use std::io;
+use std::os::windows::ffi::OsStrExt;
+use std::ptr;
+use std::mem::zeroed;
+use winapi::um::processthreadsapi::CreateProcessW;
+use winapi::um::processthreadsapi::PROCESS_INFORMATION;
+use winapi::um::processthreadsapi::STARTUPINFOW;
+use winapi::um::handleapi::CloseHandle;
+use winapi::um::winbase::CREATE_UNICODE_ENVIRONMENT;
+use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::winnt::HANDLE;
+
+/// Represents a handle to a spawned process.
+#[derive(Debug)]
+pub struct ProcessHandle {
+    pub process_handle: HANDLE,
+    pub thread_handle: HANDLE,
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.process_handle.is_null() {
+                CloseHandle(self.process_handle);
+            }
+            if !self.thread_handle.is_null() {
+                CloseHandle(self.thread_handle);
+            }
+        }
+    }
+}
+
+/// Errors that can occur when spawning a process.
+#[derive(Debug)]
+pub enum ProcessError {
+    Io(io::Error),
+    NullTermination,
+    Other(String),
+}
+
+impl From<io::Error> for ProcessError {
+    fn from(e: io::Error) -> Self {
+        ProcessError::Io(e)
+    }
+}
+
+/// Converts a Rust &str to a null-terminated UTF-16 Vec<u16> for Win32 APIs.
+fn to_wide_null(s: &str) -> Result<Vec<u16>, ProcessError> {
+    let mut wide: Vec<u16> = OsStr::new(s).encode_wide().collect();
+    if wide.contains(&0) {
+        return Err(ProcessError::NullTermination);
+    }
+    wide.push(0);
+    Ok(wide)
+}
+
+/// Spawns a new process using CreateProcessW.
+///
+/// - `exe_path`: Path to the executable.
+/// - `args`: Command-line arguments (excluding the executable name).
+/// - `current_dir`: Optional working directory.
+///
+/// Returns a ProcessHandle on success, or ProcessError on failure.
+pub fn spawn(
+    exe_path: &str,
+    args: &[&str],
+    current_dir: Option<&str>,
+) -> Result<ProcessHandle, ProcessError> {
+    // Build command line: first arg is exe_path, then args, all joined by spaces
+    let mut cmdline = String::from(exe_path);
+    for arg in args {
+        cmdline.push(' ');
+        cmdline.push_str(arg);
+    }
+    let mut cmdline_wide = to_wide_null(&cmdline)?;
+    let exe_path_wide = to_wide_null(exe_path)?;
+    let current_dir_wide = if let Some(dir) = current_dir {
+        Some(to_wide_null(dir)?)
+    } else {
+        None
+    };
+
+    unsafe {
+        let mut si: STARTUPINFOW = zeroed();
+        si.cb = std::mem::size_of::<STARTUPINFOW>() as u32;
+        let mut pi: PROCESS_INFORMATION = zeroed();
+
+        let success = CreateProcessW(
+            exe_path_wide.as_ptr(),
+            cmdline_wide.as_mut_ptr(),
+            ptr::null_mut(), // Process security attributes
+            ptr::null_mut(), // Thread security attributes
+            0,               // Inherit handles
+            CREATE_UNICODE_ENVIRONMENT,
+            ptr::null_mut(), // Environment
+            current_dir_wide
+                .as_ref()
+                .map(|v| v.as_ptr())
+                .unwrap_or(ptr::null()),
+            &mut si,
+            &mut pi,
+        );
+
+        if success == 0 {
+            let err = io::Error::from_raw_os_error(GetLastError() as i32);
+            return Err(ProcessError::Io(err));
+        }
+
+        // On success, wrap handles in ProcessHandle
+        Ok(ProcessHandle {
+            process_handle: pi.hProcess,
+            thread_handle: pi.hThread,
+        })
+    }
+} 

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1,0 +1,54 @@
+#[cfg(windows)]
+mod tests {
+    use winapi::um::synchapi::WaitForSingleObject;
+    use winapi::um::winbase::INFINITE;
+    use winix::process::{spawn, ProcessError};
+
+    #[test]
+    fn test_spawn_success_cmd() {
+        // Try to launch cmd.exe with /C exit (should exit immediately)
+        let result = spawn("C:\\Windows\\System32\\cmd.exe", &["/C", "exit"], None);
+        assert!(result.is_ok(), "Expected success, got: {:?}", result);
+        let handle = result.unwrap();
+        unsafe {
+            // Wait for process to exit
+            WaitForSingleObject(handle.process_handle, INFINITE);
+        }
+    }
+
+    #[test]
+    fn test_spawn_invalid_path() {
+        let result = spawn("C:\\not_a_real_exe.exe", &[], None);
+        assert!(result.is_err(), "Expected error for invalid path");
+        match result {
+            Err(ProcessError::Io(e)) => {
+                assert_eq!(e.kind(), std::io::ErrorKind::NotFound);
+            }
+            _ => panic!("Expected Io error for invalid path"),
+        }
+    }
+
+    #[test]
+    fn test_spawn_malformed_args() {
+        // Malformed args: include a null byte (should error in to_wide_null)
+        let result = spawn("C:\\Windows\\System32\\cmd.exe", &["/C\0"], None);
+        assert!(result.is_err(), "Expected error for malformed args");
+        match result {
+            Err(ProcessError::NullTermination) => {}
+            _ => panic!("Expected NullTermination error"),
+        }
+    }
+
+    #[test]
+    fn test_spawn_insufficient_permissions() {
+        // Try to launch a system process that requires admin (simulate by using a protected path)
+        let result = spawn("C:\\Windows\\System32\\config\\SAM", &[], None);
+        assert!(result.is_err(), "Expected error for insufficient permissions");
+        match result {
+            Err(ProcessError::Io(e)) => {
+                assert!(matches!(e.kind(), std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Other));
+            }
+            _ => panic!("Expected Io error for permission denied"),
+        }
+    }
+} 


### PR DESCRIPTION
This PR introduces a robust, safe Rust abstraction over the Windows CreateProcessW API, allowing for ergonomic and reliable process creation on Windows platforms.

Key Features

-   New Module: process module with a public spawn() function for launching processes.
-   UTF-16 Handling: Converts Rust &str to null-terminated UTF-16 as required by Win32 APIs.
-   FFI Safety: Properly initializes and manages STARTUPINFOW and PROCESS_INFORMATION structs.
-   Error Handling: Translates Windows error codes into a comprehensive Rust Result type (ProcessError).
-   Resource Management: Ensures all process and thread handles are closed in both success and failure paths to prevent leaks.
-   Library Exposure: Exposes the process module via lib.rs for use in integration tests and other crates.

Tests

- Unit tests in tests/process.rs cover:
- Successful process launch (e.g., cmd.exe /C exit)
- Failure scenarios: invalid path, malformed arguments, insufficient permissions

Usage Example
```
use winix::process::spawn;

let result = spawn("C:\\Windows\\System32\\cmd.exe", &["/C", "echo", "Hello"], None);
match result {
    Ok(handle) => println!("Process launched: {:?}", handle),
    Err(e) => eprintln!("Failed to launch process: {:?}", e),
}
```


Notes

- This abstraction is Windows-only and leverages the winapi crate.
- All unsafe code is documented and encapsulated for safety.
- The API is designed to be extensible for future process management features.