### PR TITLE
Feature/implement-unix-kill-command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 *.zip
+*.ps1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ colored = "3.0.0"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
 crossterm = "0.28.1"
 sysinfo = "0.35.1"
-winapi = { version = "0.3.9", features = ["consoleapi", "processthreadsapi", "handleapi", "winbase", "errhandlingapi", "winnt"] }
+winapi = { version = "0.3.9", features = ["consoleapi", "processthreadsapi", "handleapi", "winbase", "errhandlingapi", "winnt", "tlhelp32", "winuser"] }
 windows-acl = "0.3.0"
 dirs = "5.0"
 

--- a/src/disown.rs
+++ b/src/disown.rs
@@ -2,6 +2,7 @@ use std::env;
 use std::process::Command;
 use std::process::Stdio;
 
+#[allow(dead_code)]
 fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
     if args.is_empty() {

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -86,10 +86,174 @@ pub fn execute(args: &[&str]) -> Result<(), String> {
     handle_kill(&options)
 }
 
-// TODO: Implement these functions
 fn handle_kill(options: &KillOptions) -> Result<(), String> {
-    // Main kill logic will go here
+    debug!("Starting kill operation");
+    
+    // Handle special modes first
+    if options.print_only {
+        return handle_print_only_mode(options);
+    }
+    
+    // Determine the kill method to use
+    let signal = options.signal.as_ref()
+        .or(options.signal_explicit.as_ref())
+        .map(|s| s.as_str())
+        .unwrap_or("9"); // Default to SIGKILL if no signal specified
+    
+    let kill_method = signal_to_windows_method(signal)
+    debug!("Using kill method: {:?}", kill_method);
+    
+    // Process each target
+    let mut results = Vec::new();
+    for target in &options.targets {
+        let result = if target.chars().all(|c| c.is_ascii_digit()) {
+            // Target is a PID
+            let pid: u32 = target.parse().map_err(|_| format!("Invalid PID: {} must be a number or name", target))?;
+            kill_process_by_pid(pid, &kill_method, options)
+        } else {
+            // Target is a process name
+            kill_process_by_name(target, &kill_method, options)
+        };
+        results.push((target.clone(), result));
+    }
+    
+    // Handle timeout logic if specified
+    if let Some(timeout_ms) = options.timeout_ms {
+        handle_timeout_kill(&results, timeout_ms, options)?;
+    }
+    
+    // Report results
+    report_kill_results(&results)?;
+    
     Ok(())
+}
+
+// Handle -p flag: just print PIDs without killing
+fn handle_print_only_mode(options: &KillOptions) -> Result<(), String> {
+    debug!("Print-only mode activated");  
+    for target in &options.targets {
+        if target.chars().all(|c| c.is_ascii_digit()) {
+            println!("{}", target);
+        } else {
+            // Process name, find and print all matching PIDs
+            let pids = find_processes_by_name(target)?;
+            if pids.is_empty() {
+                return Err(format!("No processes found with name: {}", target));
+            }
+            if options.all_processes {
+                for pid in pids {
+                    println!("{}", pid);
+                }
+            } else {
+                // Just print the first one
+                println!("{}", pids[0]);
+            }
+        }
+    }
+    
+    Ok(())
+}
+
+
+// Kill a specific process by PID
+fn kill_process_by_pid(pid: u32, method: &WindowsKillMethod, options: &KillOptions) -> Result<(), String> {
+    debug!("Attempting to kill PID {} using method {:?}", pid, method);
+    
+    // Safety checks
+    validate_pid_safety(pid)?;
+    
+    // Check if process exists
+    if !process_exists(pid) {
+        return Err(format!("No such process: {}", pid));
+    }
+    
+    // Perform the actual kill operation
+    match method {
+        WindowsKillMethod::ForceTerminate => force_terminate_process(pid),
+        WindowsKillMethod::GracefulCtrlC => graceful_terminate_process(pid, false),
+        WindowsKillMethod::GracefulCtrlBreak => graceful_terminate_process(pid, true),
+        WindowsKillMethod::WindowClose => window_close_process(pid),
+    }
+}
+
+// Kill processes by name
+fn kill_process_by_name(name: &str, method: &WindowsKillMethod, options: &KillOptions) -> Result<(), String> {
+    debug!("Attempting to kill processes with name '{}' using method {:?}", name, method);
+    
+    let pids = find_processes_by_name(name)?;
+    if pids.is_empty() {
+        return Err(format!("No processes found with name: {}", name));
+    }
+    
+    let targets = if options.all_processes {
+        pids
+    } else {
+        // Just kill the first one found
+        vec![pids[0]]
+    };
+    
+    let mut errors = Vec::new();
+    let mut success_count = 0;
+    
+    for pid in targets {
+        match kill_process_by_pid(pid, method, options) {
+            Ok(_) => {
+                success_count += 1;
+                println!("{}", format!("Killed process {} ({})", pid, name).green());
+            }
+            Err(e) => {
+                errors.push(format!("Failed to kill {} ({}): {}", pid, name, e));
+            }
+        }
+    }
+    
+    if !errors.is_empty() {
+        return Err(errors.join("; "));
+    }
+    
+    if success_count == 0 {
+        return Err(format!("No processes were killed for name: {}", name));
+    }
+    
+    Ok(())
+}
+
+// Handle timeout logic: send initial signal, wait, then send final signal
+fn handle_timeout_kill(results: &[(String, Result<(), String>)], timeout_ms: u64, options: &KillOptions) -> Result<(), String> {
+    debug!("Handling timeout kill: {} ms", timeout_ms);
+    
+    // For now, this is a placeholder
+    // In a full implementation, you'd:
+    // 1. Send the initial signal (usually TERM)
+    // 2. Wait for the specified timeout
+    // 3. Check if processes are still alive
+    // 4. Send the final signal (from timeout_signal)
+    
+    println!("{}", format!("Timeout kill not yet implemented (would wait {} ms)", timeout_ms).yellow());
+    Ok(())
+}
+
+// Report the results of kill operations
+fn report_kill_results(results: &[(String, Result<(), String>)]) -> Result<(), String> {
+    let mut has_errors = false;
+    
+    for (target, result) in results {
+        match result {
+            Ok(_) => {
+                println!("{}", format!("Successfully processed target: {}", target).green());
+            }
+            Err(e) => {
+                println!("{}", format!("Failed to process {}: {}", target, e).red());
+                has_errors = true;
+            }
+        }
+    }
+    
+    if has_errors {
+        Err("Some kill operations failed".to_string())
+    } else {
+        Ok(())
+    }
 }
 
 fn parse_arguments(args: &[&str]) -> Result<KillOptions, String> {
@@ -259,5 +423,70 @@ fn signal_to_windows_method(signal: &str) -> Result<WindowsKillMethod, String> {
         "QUIT" | "3" => Ok(WindowsKillMethod::GracefulCtrlBreak),
         _ => Err(format!("Signal '{}' is not supported on Windows. Supported signals: TERM(15), INT(2), QUIT(3), KILL(9)", signal)),
     }
+}
+
+// ============================================================================
+// HELPER FUNCTIONS - These will contain the actual Windows API calls
+// ============================================================================
+
+// Check if a process exists
+fn process_exists(pid: u32) -> bool {
+    // TODO: Implement using Windows API
+    // Use OpenProcess() to check if process exists
+    debug!("Checking if process {} exists", pid);
+    true // Placeholder
+}
+
+// Safety validation for PIDs
+fn validate_pid_safety(pid: u32) -> Result<(), String> {
+    // Protect against killing critical system processes
+    const PROTECTED_PIDS: &[u32] = &[0, 4, 8]; // System, System Idle, etc.
+    
+    if PROTECTED_PIDS.contains(&pid) {
+        return Err(format!("Cannot kill system process with PID {}", pid));
+    }
+    
+    // Protect against killing current process
+    // TODO: Get current process ID and compare
+    // if pid == current_process_id() {
+    //     return Err("Cannot kill current process".to_string());
+    // }
+    
+    Ok(())
+}
+
+// Find processes by name
+fn find_processes_by_name(name: &str) -> Result<Vec<u32>, String> {
+    // TODO: Implement using Windows API
+    // Use CreateToolhelp32Snapshot() and Process32First/Process32Next
+    debug!("Finding processes with name: {}", name);
+    
+    // Placeholder - return empty vec for now
+    Ok(vec![])
+}
+
+// Force terminate a process (SIGKILL equivalent)
+fn force_terminate_process(pid: u32) -> Result<(), String> {
+    // TODO: Implement using TerminateProcess()
+    debug!("Force terminating process {}", pid);
+    println!("{}", format!("Force terminated process {}", pid).green());
+    Ok(())
+}
+
+// Graceful terminate using console control events (SIGTERM/SIGINT)
+fn graceful_terminate_process(pid: u32, use_ctrl_break: bool) -> Result<(), String> {
+    // TODO: Implement using GenerateConsoleCtrlEvent()
+    let signal_type = if use_ctrl_break { "Ctrl+Break" } else { "Ctrl+C" };
+    debug!("Gracefully terminating process {} with {}", pid, signal_type);
+    println!("{}", format!("Sent {} to process {}", signal_type, pid).green());
+    Ok(())
+}
+
+// Close process by sending WM_CLOSE to its windows
+fn window_close_process(pid: u32) -> Result<(), String> {
+    // TODO: Implement using EnumWindows() and PostMessage(WM_CLOSE)
+    debug!("Closing windows for process {}", pid);
+    println!("{}", format!("Sent close message to process {}", pid).green());
+    Ok(())
 }
 

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -40,7 +40,7 @@ use winapi::um::wincon::{GenerateConsoleCtrlEvent, CTRL_C_EVENT, CTRL_BREAK_EVEN
 use winapi::um::winuser::{EnumWindows, GetWindowThreadProcessId, PostMessageW, WM_CLOSE};
 use winapi::um::tlhelp32::{CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS};
 use winapi::shared::windef::{HWND};
-use winapi::shared::minwindef::{BOOL, DWORD, TRUE, FALSE, LPARAM};
+use winapi::shared::minwindef::{BOOL, DWORD, TRUE, LPARAM};
 
 // Simple debug macro replacement
 macro_rules! debug {
@@ -61,6 +61,7 @@ pub struct KillOptions {
 }
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub enum WindowsKillMethod {
     ForceTerminate,    // SIGKILL (9) -> TerminateProcess
     GracefulCtrlC,     // SIGTERM (15), SIGINT (2) -> Ctrl+C

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -1,0 +1,230 @@
+/*
+This file tries to mimic the behavior of the Unix `kill` command
+for Windows, allowing users to terminate processes by PID.
+
+The Unix definition for 'kill' is:
+kill [-signal|-s signal|-p] [-q value] [-a] [--timeout milliseconds signal] [--] pid|name...
+We will follow this structure closely.
+
+Arguments breakdown:
+- -signal (e.g., -9, -TERM): Specify signal number or name //Windows does not use signals like Unix, but we can simulate this.
+- -s signal: Alternative signal specification  
+- -p: Print PID only, don't send signal
+- -q value: Send signal with additional data
+- -a: Apply to all processes with given name
+- --timeout ms signal: Send signal, wait, then send second signal
+- --: End of options marker
+- pid|name...: Process IDs or names to target
+
+Key things addressed:
+1. Parsing command line arguments.
+2. Checking if the PID is valid, the checks includes:
+    - Protection against killing the current process.
+    - Protecting against killing system processes.
+    - Handling invalid PIDs. (Like negative or non-numeric values).
+    - Handling non-existent PIDs. (Like out of bounds values)
+3. Checking if process with specified name exists and is valid to be killed.
+4. Implementing all arguments supported by unix
+*/
+
+use colored::*;
+
+#[derive(Debug, Clone)]
+pub struct KillOptions {
+    pub signal: Option<String>,          // Signal
+    pub signal_explicit: Option<String>, // Signal from -s flag
+    pub print_only: bool,                // -p flag
+    pub queue_value: Option<i32>,        // -q value
+    pub all_processes: bool,             // -a flag
+    pub timeout_ms: Option<u64>,         // --timeout milliseconds
+    pub timeout_signal: Option<String>,  // Signal to send after timeout
+    pub end_of_options: bool,            // -- encountered
+    pub targets: Vec<String>,            // PIDs or process names
+}
+
+impl Default for KillOptions {
+    fn default() -> Self {
+        KillOptions {
+            signal: None,
+            signal_explicit: None,
+            print_only: false,
+            queue_value: None,
+            all_processes: false,
+            timeout_ms: None,
+            timeout_signal: None,
+            end_of_options: false,
+            targets: Vec::new(),
+        }
+    }
+}
+
+pub fn execute(args: &[&str]) -> Result<(), String> {
+    if args.is_empty() {
+        return Err("Usage: kill [-signal|-s signal|-p] [-q value] [-a] [--timeout milliseconds signal] [--] pid|name...".to_string());
+    }
+
+    let options = parse_arguments(args)?;
+    validate_options(&options)?;
+    
+    // TODO: Implement the actual kill logic here
+    // For now, just print what we parsed
+    println!("Parsed options: {:?}", options);
+    
+    Ok(())
+}
+
+fn parse_arguments(args: &[&str]) -> Result<KillOptions, String> {
+    let mut options = KillOptions::default();
+    let mut i = 0;
+    
+    while i < args.len() {
+        let arg = args[i];
+        
+        // If we've seen --, everything else is a target
+        if options.end_of_options {
+            options.targets.push(arg.to_string());
+            i += 1;
+            continue;
+        }
+        
+        match arg {
+            // End of options marker
+            "--" => {
+                options.end_of_options = true;
+            }
+            
+            // Print PID only
+            "-p" => {
+                options.print_only = true;
+            }
+            
+            // All processes flag
+            "-a" => {
+                options.all_processes = true;
+            }
+            
+            // Explicit signal flag
+            "-s" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("Option -s requires a signal argument".to_string());
+                }
+                options.signal_explicit = Some(args[i].to_string());
+            }
+            
+            // Queue value flag
+            "-q" => {
+                i += 1;
+                if i >= args.len() {
+                    return Err("Option -q requires a value argument".to_string());
+                }
+                match args[i].parse::<i32>() {
+                    Ok(val) => options.queue_value = Some(val),
+                    Err(_) => return Err(format!("Invalid queue value: {}", args[i])),
+                }
+            }
+            
+            // Timeout option
+            arg if arg.starts_with("--timeout") => {
+                if arg.contains('=') {
+                    // Format: --timeout=5000
+                    let parts: Vec<&str> = arg.splitn(2, '=').collect();
+                    if parts.len() != 2 {
+                        return Err("Invalid --timeout format".to_string());
+                    }
+                    match parts[1].parse::<u64>() {
+                        Ok(ms) => options.timeout_ms = Some(ms),
+                        Err(_) => return Err(format!("Invalid timeout value: {}", parts[1])),
+                    }
+                } else {
+                    // Format: --timeout 5000 SIGNAL
+                    i += 1;
+                    if i >= args.len() {
+                        return Err("Option --timeout requires milliseconds argument".to_string());
+                    }
+                    match args[i].parse::<u64>() {
+                        Ok(ms) => options.timeout_ms = Some(ms),
+                        Err(_) => return Err(format!("Invalid timeout value: {}", args[i])),
+                    }
+                    
+                    // Next argument should be the signal
+                    i += 1;
+                    if i >= args.len() {
+                        return Err("Option --timeout requires a signal argument".to_string());
+                    }
+                    options.timeout_signal = Some(args[i].to_string());
+                }
+            }
+            
+            // Signal arguments (start with -)
+            arg if arg.starts_with('-') && arg.len() > 1 => {
+                let signal = &arg[1..]; // Remove the leading -
+                
+                // Check if it's a valid signal (number or name)
+                if signal.chars().all(|c| c.is_ascii_digit()) {
+                    // Numeric signal
+                    options.signal = Some(signal.to_string());
+                } else if is_valid_signal_name(signal) {
+                    // Named signal
+                    options.signal = Some(signal.to_string());
+                } else {
+                    return Err(format!("Invalid signal: -{}", signal));
+                }
+            }
+            
+            // Everything else is a target (PID or process name)
+            _ => {
+                options.targets.push(arg.to_string());
+            }
+        }
+        
+        i += 1;
+    }
+    
+    Ok(options)
+}
+
+fn validate_options(options: &KillOptions) -> Result<(), String> {
+    // Must have at least one target unless using -p with no targets
+    if options.targets.is_empty() && !options.print_only {
+        return Err("No process ID or name specified".to_string());
+    }
+    
+    // Cannot use both -s signal and -signal
+    if options.signal.is_some() && options.signal_explicit.is_some() {
+        return Err("Cannot specify signal with both -signal and -s options".to_string());
+    }
+    
+    // -a flag only makes sense with process names, not PIDs
+    if options.all_processes {
+        for target in &options.targets {
+            if target.chars().all(|c| c.is_ascii_digit()) {
+                return Err("Cannot use -a flag with numeric PIDs".to_string());
+            }
+        }
+    }
+    
+    // Timeout requires a signal
+    if options.timeout_ms.is_some() && options.timeout_signal.is_none() {
+        return Err("--timeout option requires a signal".to_string());
+    }
+    
+    Ok(())
+}
+
+fn is_valid_signal_name(signal: &str) -> bool {
+    // Common Unix signal names
+    matches!(signal.to_uppercase().as_str(),
+        "HUP" | "INT" | "QUIT" | "ILL" | "TRAP" | "ABRT" | "BUS" | "FPE" |
+        "KILL" | "USR1" | "SEGV" | "USR2" | "PIPE" | "ALRM" | "TERM" |
+        "STKFLT" | "CHLD" | "CONT" | "STOP" | "TSTP" | "TTIN" | "TTOU" |
+        "URG" | "XCPU" | "XFSZ" | "VTALRM" | "PROF" | "WINCH" | "IO" |
+        "PWR" | "SYS"
+    )
+}
+
+// TODO: Implement these functions
+fn handle_kill(options: &KillOptions) -> Result<(), String> {
+    // Main kill logic will go here
+    Ok(())
+}

--- a/src/kill.rs
+++ b/src/kill.rs
@@ -31,6 +31,17 @@ Key things addressed:
 
 use colored::*;
 use log::debug;
+use std::thread;
+use std::time::Duration;
+use winapi::um::processthreadsapi::{OpenProcess, TerminateProcess, GetCurrentProcessId};
+use winapi::um::winnt::{PROCESS_TERMINATE, PROCESS_QUERY_INFORMATION};
+use winapi::um::handleapi::{CloseHandle, INVALID_HANDLE_VALUE};
+use winapi::um::errhandlingapi::GetLastError;
+use winapi::um::wincon::{GenerateConsoleCtrlEvent, CTRL_C_EVENT, CTRL_BREAK_EVENT};
+use winapi::um::winuser::{EnumWindows, GetWindowThreadProcessId, PostMessageW, WM_CLOSE};
+use winapi::um::tlhelp32::{CreateToolhelp32Snapshot, Process32First, Process32Next, PROCESSENTRY32, TH32CS_SNAPPROCESS};
+use winapi::shared::windef::{HWND, LPARAM};
+use winapi::shared::minwindef::{BOOL, DWORD, TRUE, FALSE};
 
 #[derive(Debug, Clone)]
 pub struct KillOptions {
@@ -43,6 +54,14 @@ pub struct KillOptions {
     pub timeout_signal: Option<String>,  // Signal to send after timeout
     pub end_of_options: bool,            // -- encountered
     pub targets: Vec<String>,            // PIDs or process names
+}
+
+#[derive(Debug, Clone)]
+pub enum WindowsKillMethod {
+    ForceTerminate,    // SIGKILL (9) -> TerminateProcess
+    GracefulCtrlC,     // SIGTERM (15), SIGINT (2) -> Ctrl+C
+    GracefulCtrlBreak, // SIGQUIT (3) -> Ctrl+Break
+    WindowClose,       // For GUI applications
 }
 
 impl Default for KillOptions {
@@ -100,7 +119,7 @@ fn handle_kill(options: &KillOptions) -> Result<(), String> {
         .map(|s| s.as_str())
         .unwrap_or("9"); // Default to SIGKILL if no signal specified
     
-    let kill_method = signal_to_windows_method(signal)
+    let kill_method = signal_to_windows_method(signal)?;
     debug!("Using kill method: {:?}", kill_method);
     
     // Process each target
@@ -158,16 +177,10 @@ fn handle_print_only_mode(options: &KillOptions) -> Result<(), String> {
 // Kill a specific process by PID
 fn kill_process_by_pid(pid: u32, method: &WindowsKillMethod, options: &KillOptions) -> Result<(), String> {
     debug!("Attempting to kill PID {} using method {:?}", pid, method);
-    
-    // Safety checks
     validate_pid_safety(pid)?;
-    
-    // Check if process exists
     if !process_exists(pid) {
         return Err(format!("No such process: {}", pid));
     }
-    
-    // Perform the actual kill operation
     match method {
         WindowsKillMethod::ForceTerminate => force_terminate_process(pid),
         WindowsKillMethod::GracefulCtrlC => graceful_terminate_process(pid, false),
@@ -184,11 +197,9 @@ fn kill_process_by_name(name: &str, method: &WindowsKillMethod, options: &KillOp
     if pids.is_empty() {
         return Err(format!("No processes found with name: {}", name));
     }
-    
     let targets = if options.all_processes {
         pids
     } else {
-        // Just kill the first one found
         vec![pids[0]]
     };
     
@@ -206,11 +217,9 @@ fn kill_process_by_name(name: &str, method: &WindowsKillMethod, options: &KillOp
             }
         }
     }
-    
     if !errors.is_empty() {
         return Err(errors.join("; "));
     }
-    
     if success_count == 0 {
         return Err(format!("No processes were killed for name: {}", name));
     }
@@ -222,21 +231,111 @@ fn kill_process_by_name(name: &str, method: &WindowsKillMethod, options: &KillOp
 fn handle_timeout_kill(results: &[(String, Result<(), String>)], timeout_ms: u64, options: &KillOptions) -> Result<(), String> {
     debug!("Handling timeout kill: {} ms", timeout_ms);
     
-    // For now, this is a placeholder
-    // In a full implementation, you'd:
-    // 1. Send the initial signal (usually TERM)
-    // 2. Wait for the specified timeout
-    // 3. Check if processes are still alive
-    // 4. Send the final signal (from timeout_signal)
+    // Get the timeout signal (this should be validated already)
+    let timeout_signal = options.timeout_signal.as_ref().ok_or("Timeout signal not specified")?;
+    let timeout_method = signal_to_windows_method(timeout_signal)?;
+    println!("{}", format!("Timeout kill: waiting {} ms before sending {} signal", timeout_ms, timeout_signal).yellow());
+    // Collect PIDs from successful initial kills
+    let mut target_pids = Vec::new();
+    for (target, result) in results {
+        if result.is_ok() {
+            // Try to parse as PID, or find processes by name
+            if target.chars().all(|c| c.is_ascii_digit()) {
+                if let Ok(pid) = target.parse::<u32>() {
+                    target_pids.push((pid, target.clone()));
+                }
+            } else {
+                // For process names, we need to find PIDs again
+                // (they might have changed since initial kill)
+                match find_processes_by_name(target) {
+                    Ok(pids) => {
+                        if options.all_processes {
+                            for pid in pids {
+                                target_pids.push((pid, target.clone()));
+                            }
+                        } else if !pids.is_empty() {
+                            target_pids.push((pids[0], target.clone()));
+                        }
+                    }
+                    Err(_) => {
+                        debug!("Could not find processes for name '{}' during timeout check", target);
+                    }
+                }
+            }
+        }
+    }
     
-    println!("{}", format!("Timeout kill not yet implemented (would wait {} ms)", timeout_ms).yellow());
+    if target_pids.is_empty() {
+        println!("{}", "No processes to check for timeout kill".yellow());
+        return Ok(());
+    }
+    
+    // Wait for the specified timeout
+    println!("{}", format!("Waiting {} ms for processes to terminate gracefully...", timeout_ms).cyan());
+    thread::sleep(Duration::from_millis(timeout_ms));
+    
+    // Check which processes are still alive and kill them with the timeout signal
+    let mut still_alive = Vec::new();
+    for (pid, target_name) in target_pids {
+        if process_exists(pid) {
+            still_alive.push((pid, target_name));
+        } else {
+            println!("{}", format!("Process {} ({}) terminated gracefully", pid, target_name).green());
+        }
+    }
+    
+    if still_alive.is_empty() {
+        println!("{}", "All processes terminated gracefully within timeout period".green());
+        return Ok(());
+    }
+    
+    // Kill remaining processes with the timeout signal
+    println!("{}", format!("Sending {} signal to {} remaining process(es)", timeout_signal, still_alive.len()).yellow());
+    
+    let mut timeout_errors = Vec::new();
+    let mut timeout_success = 0;
+    
+    for (pid, target_name) in still_alive {
+        debug!("Sending timeout signal {} to process {} ({})", timeout_signal, pid, target_name);
+        
+        // Validate safety again (process might have changed)
+        if let Err(e) = validate_pid_safety(pid) {
+            timeout_errors.push(format!("Cannot kill {} ({}): {}", pid, target_name, e));
+            continue;
+        }
+        match kill_process_with_method(pid, &timeout_method) {
+            Ok(_) => {
+                timeout_success += 1;
+                println!("{}", format!("Timeout kill: {} sent to process {} ({})", timeout_signal, pid, target_name).green());
+            }
+            Err(e) => {
+                timeout_errors.push(format!("Timeout kill failed for {} ({}): {}", pid, target_name, e));
+            }
+        }
+    }
+    if !timeout_errors.is_empty() {
+        println!("{}", format!("Timeout kill errors: {}", timeout_errors.join("; ")).red());
+    }
+    if timeout_success > 0 {
+        println!("{}", format!("Timeout kill completed: {} process(es) killed with {}", timeout_success, timeout_signal).green());
+    }
+    
     Ok(())
+}
+
+// Helper function to kill a process with a specific method
+fn kill_process_with_method(pid: u32, method: &WindowsKillMethod) -> Result<(), String> {
+    match method {
+        WindowsKillMethod::ForceTerminate => force_terminate_process(pid),
+        WindowsKillMethod::GracefulCtrlC => graceful_terminate_process(pid, false),
+        WindowsKillMethod::GracefulCtrlBreak => graceful_terminate_process(pid, true),
+        WindowsKillMethod::WindowClose => window_close_process(pid),
+    }
 }
 
 // Report the results of kill operations
 fn report_kill_results(results: &[(String, Result<(), String>)]) -> Result<(), String> {
     let mut has_errors = false;
-    
     for (target, result) in results {
         match result {
             Ok(_) => {
@@ -248,13 +347,17 @@ fn report_kill_results(results: &[(String, Result<(), String>)]) -> Result<(), S
             }
         }
     }
-    
     if has_errors {
         Err("Some kill operations failed".to_string())
     } else {
         Ok(())
     }
 }
+
+// ============================================================================
+// Helper Functions 
+// ============================================================================
+
 
 fn parse_arguments(args: &[&str]) -> Result<KillOptions, String> {
     let mut options = KillOptions::default();
@@ -395,8 +498,6 @@ fn validate_options(options: &KillOptions) -> Result<(), String> {
     Ok(())
 }
 
-// Helper function to check if a signal name is valid
-// Only supports signals that can be reasonably simulated on Windows
 fn is_valid_signal_name(signal: &str) -> bool {
     matches!(signal.to_uppercase().as_str(),
         // Termination signals
@@ -404,15 +505,6 @@ fn is_valid_signal_name(signal: &str) -> bool {
         // Numeric equivalents
         "2" | "3" | "9" | "15"
     )
-}
-
-// Map Unix signal to Windows termination method
-#[derive(Debug, Clone)]
-pub enum WindowsKillMethod {
-    ForceTerminate,    // SIGKILL (9) -> TerminateProcess
-    GracefulCtrlC,     // SIGTERM (15), SIGINT (2) -> Ctrl+C
-    GracefulCtrlBreak, // SIGQUIT (3) -> Ctrl+Break
-    WindowClose,       // For GUI applications
 }
 
 fn signal_to_windows_method(signal: &str) -> Result<WindowsKillMethod, String> {
@@ -425,68 +517,245 @@ fn signal_to_windows_method(signal: &str) -> Result<WindowsKillMethod, String> {
     }
 }
 
-// ============================================================================
-// HELPER FUNCTIONS - These will contain the actual Windows API calls
-// ============================================================================
-
-// Check if a process exists
 fn process_exists(pid: u32) -> bool {
-    // TODO: Implement using Windows API
-    // Use OpenProcess() to check if process exists
     debug!("Checking if process {} exists", pid);
-    true // Placeholder
+    unsafe {
+        // Try to open the process with minimal rights just to check existence
+        let process_handle = OpenProcess(
+            PROCESS_QUERY_INFORMATION,
+            0, // bInheritHandle = FALSE
+            pid
+        );
+        
+        if process_handle.is_null() {
+            debug!("Process {} does not exist or cannot be accessed", pid);
+            return false;
+        }
+        
+        // Process exists and we can access it
+        CloseHandle(process_handle);
+        debug!("Process {} exists and is accessible", pid);
+        true
+    }
 }
 
 // Safety validation for PIDs
 fn validate_pid_safety(pid: u32) -> Result<(), String> {
     // Protect against killing critical system processes
     const PROTECTED_PIDS: &[u32] = &[0, 4, 8]; // System, System Idle, etc.
-    
     if PROTECTED_PIDS.contains(&pid) {
         return Err(format!("Cannot kill system process with PID {}", pid));
     }
-    
     // Protect against killing current process
-    // TODO: Get current process ID and compare
-    // if pid == current_process_id() {
-    //     return Err("Cannot kill current process".to_string());
-    // }
-    
+    unsafe {
+        let current_pid = GetCurrentProcessId();
+        if pid == current_pid {
+            return Err("Cannot kill current process".to_string());
+        }
+    }
     Ok(())
 }
 
 // Find processes by name
 fn find_processes_by_name(name: &str) -> Result<Vec<u32>, String> {
-    // TODO: Implement using Windows API
-    // Use CreateToolhelp32Snapshot() and Process32First/Process32Next
     debug!("Finding processes with name: {}", name);
+    let mut matching_pids = Vec::new();
     
-    // Placeholder - return empty vec for now
-    Ok(vec![])
+    unsafe {
+        // Take a snapshot of all processes in the system
+        let snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if snapshot == winapi::um::handleapi::INVALID_HANDLE_VALUE {
+            let error_code = GetLastError();
+            return Err(format!("Failed to create process snapshot: Windows error code {}", error_code));
+        }
+        // Initialize the PROCESSENTRY32 structure
+        let mut process_entry: PROCESSENTRY32 = std::mem::zeroed();
+        process_entry.dwSize = std::mem::size_of::<PROCESSENTRY32>() as DWORD;
+        // Get the first process in the snapshot
+        let mut result = Process32First(snapshot, &mut process_entry);
+        if result == 0 {
+            CloseHandle(snapshot);
+            let error_code = GetLastError();
+            return Err(format!("Failed to get first process: Windows error code {}", error_code));
+        }
+        
+        // Iterate through all processes in the snapshot
+        loop {
+            // Convert the szExeFile (which is a null-terminated C string) to a Rust string
+            let exe_name = std::ffi::CStr::from_ptr(process_entry.szExeFile.as_ptr())
+                .to_string_lossy()
+                .to_lowercase();
+            let target_name = name.to_lowercase();
+            
+            // Check if the process name matches (with or without .exe extension)
+            let matches = exe_name == target_name 
+                || exe_name == format!("{}.exe", target_name)
+                || (exe_name.ends_with(".exe") && exe_name[..exe_name.len()-4] == target_name);
+            if matches {
+                debug!("Found matching process: {} (PID: {})", exe_name, process_entry.th32ProcessID);
+                matching_pids.push(process_entry.th32ProcessID);
+            }
+            
+            // Move to the next process
+            result = Process32Next(snapshot, &mut process_entry);
+            if result == 0 {
+                break; // No more processes
+            }
+        }
+
+        // Clean up the snapshot handle
+        CloseHandle(snapshot);
+    }
+    
+    debug!("Found {} processes matching name '{}'", matching_pids.len(), name);
+    Ok(matching_pids)
 }
 
 // Force terminate a process (SIGKILL equivalent)
 fn force_terminate_process(pid: u32) -> Result<(), String> {
-    // TODO: Implement using TerminateProcess()
-    debug!("Force terminating process {}", pid);
-    println!("{}", format!("Force terminated process {}", pid).green());
-    Ok(())
+    debug!("Force terminating process {} using TerminateProcess", pid);
+    unsafe {
+        // Open the process with termination rights
+        let process_handle = OpenProcess(
+            PROCESS_TERMINATE | PROCESS_QUERY_INFORMATION, 
+            0, // bInheritHandle = FALSE
+            pid
+        );
+        
+        if process_handle.is_null() {
+            let error_code = GetLastError();
+            return match error_code {
+                5 => Err(format!("Access denied: Cannot terminate process {} (insufficient privileges)", pid)),
+                87 => Err(format!("Invalid PID: Process {} does not exist", pid)),
+                _ => Err(format!("Failed to open process {}: Windows error code {}", pid, error_code)),
+            };
+        }
+        
+        // Attempt to terminate the process
+        let result = TerminateProcess(
+            process_handle,
+            1 // Exit code - using 1 to indicate forced termination
+        );
+        
+        // Clean up the handle
+        CloseHandle(process_handle);
+        
+        if result == 0 {
+            let error_code = GetLastError();
+            return match error_code {
+                5 => Err(format!("Access denied: Cannot terminate process {} (protected process)", pid)),
+                _ => Err(format!("Failed to terminate process {}: Windows error code {}", pid, error_code)),
+            };
+        }
+        
+        println!("{}", format!("Force terminated process {} (SIGKILL)", pid).green());
+        Ok(())
+    }
 }
 
-// Graceful terminate using console control events (SIGTERM/SIGINT)
+// Graceful terminate using console control events (SIGINT/SIGQUIT)
 fn graceful_terminate_process(pid: u32, use_ctrl_break: bool) -> Result<(), String> {
-    // TODO: Implement using GenerateConsoleCtrlEvent()
-    let signal_type = if use_ctrl_break { "Ctrl+Break" } else { "Ctrl+C" };
+    let (signal_type, ctrl_event) = if use_ctrl_break {
+        ("Ctrl+Break (SIGQUIT)", CTRL_BREAK_EVENT)
+    } else {
+        ("Ctrl+C (SIGINT)", CTRL_C_EVENT)
+    };
+    
     debug!("Gracefully terminating process {} with {}", pid, signal_type);
-    println!("{}", format!("Sent {} to process {}", signal_type, pid).green());
-    Ok(())
+    
+    unsafe {
+        let result = GenerateConsoleCtrlEvent(ctrl_event, pid);
+        
+        if result == 0 {
+            let error_code = GetLastError();
+            return match error_code {
+                6 => Err(format!("Invalid handle: Process {} is not a console process or not accessible", pid)),
+                87 => Err(format!("Invalid parameter: Process {} may not exist or not be a console application", pid)),
+                _ => {
+                    // Fallback: If console control event fails, try alternative approaches
+                    debug!("Console control event failed (error {}), attempting alternative graceful termination", error_code);
+                    return graceful_terminate_fallback(pid, use_ctrl_break);
+                }
+            };
+        }
+        
+        println!("{}", format!("Sent {} to process {}", signal_type, pid).green());
+        Ok(())
+    }
+}
+
+// Fallback graceful termination for non-console applications
+fn graceful_terminate_fallback(pid: u32, use_ctrl_break: bool) -> Result<(), String> {
+    let signal_type = if use_ctrl_break { "Ctrl+Break" } else { "Ctrl+C" };
+    
+    debug!("Using fallback graceful termination for process {}", pid);
+    match window_close_process(pid) {
+        Ok(_) => {
+            println!("{}", format!("Sent window close message to process {} (fallback for {})", pid, signal_type).yellow());
+            Ok(())
+        }
+        Err(_) => {
+            println!("{}", format!("Warning: Graceful termination failed for process {}, using force termination", pid).yellow());
+            force_terminate_process(pid)
+        }
+    }
 }
 
 // Close process by sending WM_CLOSE to its windows
 fn window_close_process(pid: u32) -> Result<(), String> {
-    // TODO: Implement using EnumWindows() and PostMessage(WM_CLOSE)
-    debug!("Closing windows for process {}", pid);
-    println!("{}", format!("Sent close message to process {}", pid).green());
-    Ok(())
+    debug!("Attempting to close windows for process {}", pid);
+    unsafe {
+        let mut data = EnumWindowsData {
+            target_pid: pid,
+            windows_found: 0,
+            windows_closed: 0,
+        };
+        // Enumerate all top-level windows and send WM_CLOSE to those owned by our target process
+        let result = EnumWindows(
+            Some(enum_windows_proc), 
+            &mut data as *mut EnumWindowsData as LPARAM
+        );
+        if result == 0 {
+            let error_code = GetLastError();
+            return Err(format!("Failed to enumerate windows: Windows error code {}", error_code));
+        }
+        if data.windows_found == 0 {
+            return Err(format!("No windows found for process {} (may be a console-only or background process)", pid));
+        }
+        if data.windows_closed == 0 {
+            return Err(format!("Found {} windows for process {} but failed to send close messages", data.windows_found, pid));
+        }
+        println!("{}", format!("Sent close message to {} window(s) of process {}", data.windows_closed, pid).green());
+        Ok(())
+    }
+}
+
+// Structure to pass data to the window enumeration callback
+#[repr(C)]
+struct EnumWindowsData {
+    target_pid: DWORD,
+    windows_found: u32,
+    windows_closed: u32,
+}
+
+// Callback function for EnumWindows
+unsafe extern "system" fn enum_windows_proc(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    let data = &mut *(lparam as *mut EnumWindowsData);
+    let mut window_pid: DWORD = 0;
+    // Get the process ID that owns this window
+    GetWindowThreadProcessId(hwnd, &mut window_pid);
+    // If this window belongs to our target process
+    if window_pid == data.target_pid {
+        data.windows_found += 1;
+        debug!("Found window for process {}, sending WM_CLOSE", data.target_pid);
+        
+        // Send WM_CLOSE message to the window
+        let result = PostMessageW(hwnd, WM_CLOSE, 0, 0);
+        if result != 0 {
+            data.windows_closed += 1;
+        }
+    }
+
+    TRUE // Continue enumeration
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
-pub mod process; 
+pub mod process;
+pub mod kill; 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,17 +6,19 @@ use std::io::{self, Write};
 mod cd;
 mod chmod;
 mod chown;
+mod disown;
 mod df;
 mod free;
 mod git;
+mod kill;
 mod powershell;
 mod ps;
 mod sensors;
+mod sudo;
 mod tui;
 mod uname;
 mod uptime;
-mod sudo;
-mod disown;
+
 
 fn main() {
     test_sudo();
@@ -72,20 +74,21 @@ fn show_splash_screen() {
     println!("{}", "Available Commands:".bold().white());
     println!(
         "  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}",
+        "cd".bold().yellow(),
         "chmod".bold().yellow(),
         "chown".bold().yellow(),
-        "uname".bold().yellow(),
-        "ps".bold().yellow(),
-        "sensors".bold().yellow(),
-        "free".bold().yellow(),
-        "uptime".bold().yellow(),
         "df".bold().yellow(),
-        "cd".bold().yellow(),
-        "pwd".bold().yellow(),
-        "ls".bold().yellow(),
-        "git".bold().yellow(),
-        "psh/powershell".bold().cyan(),
         "exit".bold().red()
+        "free".bold().yellow(),
+        "git".bold().yellow(),
+        "kill".bold().yellow(),
+        "ls".bold().yellow(),
+        "ps".bold().yellow(),
+        "psh/powershell".bold().cyan(),
+        "pwd".bold().yellow(),
+        "sensors".bold().yellow(),
+        "uptime".bold().yellow(),
+        "uname".bold().yellow(),
     );
     println!();
 }
@@ -221,6 +224,28 @@ fn command_loop() {
                     git::execute(&args);
                 }
             }
+            "kill" => {
+                if parts.len() < 2 {
+                    println!("{}", "Usage: kill [-signal|-s signal|-p] [-q value] [-a] [--timeout milliseconds signal] [--] pid|name...".red());
+                    println!();
+                    println!("{}", "Examples:".yellow());
+                    println!("  {}", "kill 1234".dimmed());
+                    println!("  {}", "kill -9 1234".dimmed());
+                    println!("  {}", "kill -TERM 1234".dimmed());
+                    println!("  {}", "kill -s KILL 1234".dimmed());
+                    println!("  {}", "kill -p 1234".dimmed());
+                    println!("  {}", "kill -a notepad".dimmed());
+                    println!("  {}", "kill --timeout 5000 KILL 1234".dimmed());
+                    println!("  {}", "kill -- -1234".dimmed());
+                } else {
+                    // Pass all arguments except the command itself
+                    let args: Vec<&str> = parts[1..].to_vec();
+                    match kill::execute(&args) {
+                        Ok(_) => {}
+                        Err(e) => println!("{}", format!("kill: {}", e).red()),
+                    }
+                }
+            }
             "psh" | "powershell" => {
                 if parts.len() == 1 {
                     // Show PowerShell help if no arguments
@@ -259,20 +284,21 @@ fn command_loop() {
                 println!("{}", "Available Commands:".bold().white());
                 println!(
                     "  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}",
-                    "chmod <permissions> <file>".bold().yellow(),
-                    "chown <owner_name> <file>".bold().yellow(),
-                    "uname".bold().yellow(),
-                    "ps".bold().yellow(),
-                    "sensors".bold().yellow(),
-                    "free".bold().yellow(),
-                    "uptime".bold().yellow(),
+                    "cd".bold().yellow(),
+                    "chmod".bold().yellow(),
+                    "chown".bold().yellow(),
                     "df".bold().yellow(),
-                    "cd <directory>".bold().yellow(),
+                    "exit".bold().red()
+                    "free".bold().yellow(),
+                    "git".bold().yellow(),
+                    "kill".bold().yellow(),
+                    "ls".bold().yellow(),
+                    "ps".bold().yellow(),
+                    "psh/powershell".bold().cyan(),
                     "pwd".bold().yellow(),
-                    "ls [directory]".bold().yellow(),
-                    "git [command] [options]".bold().yellow(),
-                    "psh/powershell [command] [options]".bold().cyan(),
-                    "exit or quit".bold().red()
+                    "sensors".bold().yellow(),
+                    "uptime".bold().yellow(),
+                    "uname".bold().yellow(),
                 );
             }
             _ => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,15 +228,17 @@ fn command_loop() {
                 if parts.len() < 2 {
                     println!("{}", "Usage: kill [-signal|-s signal|-p] [-q value] [-a] [--timeout milliseconds signal] [--] pid|name...".red());
                     println!();
+                    println!("{}", "Supported Windows signals:".yellow());
+                    println!("  {}", "-2, -INT    Interrupt (Ctrl+C)".dimmed());
+                    println!("  {}", "-3, -QUIT   Quit (Ctrl+Break)".dimmed());
+                    println!("  {}", "-9, -KILL   Force terminate (default)".dimmed());
+                    println!("  {}", "-15, -TERM  Graceful terminate".dimmed());
+                    println!();
                     println!("{}", "Examples:".yellow());
                     println!("  {}", "kill 1234".dimmed());
-                    println!("  {}", "kill -9 1234".dimmed());
                     println!("  {}", "kill -TERM 1234".dimmed());
-                    println!("  {}", "kill -s KILL 1234".dimmed());
-                    println!("  {}", "kill -p 1234".dimmed());
+                    println!("  {}", "kill -9 1234".dimmed());
                     println!("  {}", "kill -a notepad".dimmed());
-                    println!("  {}", "kill --timeout 5000 KILL 1234".dimmed());
-                    println!("  {}", "kill -- -1234".dimmed());
                 } else {
                     // Pass all arguments except the command itself
                     let args: Vec<&str> = parts[1..].to_vec();

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,12 +73,12 @@ fn show_splash_screen() {
     println!();
     println!("{}", "Available Commands:".bold().white());
     println!(
-        "  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}",
+        "  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}",
         "cd".bold().yellow(),
         "chmod".bold().yellow(),
         "chown".bold().yellow(),
         "df".bold().yellow(),
-        "exit".bold().red()
+        "exit".bold().red(),
         "free".bold().yellow(),
         "git".bold().yellow(),
         "kill".bold().yellow(),
@@ -285,12 +285,12 @@ fn command_loop() {
             "help" => {
                 println!("{}", "Available Commands:".bold().white());
                 println!(
-                    "  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}",
+                    "  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}\n  {}",
                     "cd".bold().yellow(),
                     "chmod".bold().yellow(),
                     "chown".bold().yellow(),
                     "df".bold().yellow(),
-                    "exit".bold().red()
+                    "exit".bold().red(),
                     "free".bold().yellow(),
                     "git".bold().yellow(),
                     "kill".bold().yellow(),

--- a/src/powershell.rs
+++ b/src/powershell.rs
@@ -246,6 +246,7 @@ fn show_powershell_help() {
 }
 
 /// Get PowerShell version information
+#[allow(dead_code)]
 pub fn get_version_info() -> Option<String> {
     let ps_exe = get_powershell_executable();
     match Command::new(ps_exe)
@@ -269,6 +270,7 @@ pub fn get_version_info() -> Option<String> {
 }
 
 /// Check if current directory is accessible via PowerShell
+#[allow(dead_code)]
 pub fn test_current_directory() -> bool {
     let ps_exe = get_powershell_executable();
     match Command::new(ps_exe)

--- a/src/sudo.rs
+++ b/src/sudo.rs
@@ -1,6 +1,7 @@
 #[cfg(target_family = "unix")]
 use std::process::Command;
 
+#[allow(dead_code)]
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
 

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -25,6 +25,7 @@ use std::time::{Duration, Instant};
 pub struct App {
     pub selected_tab: usize,
     pub should_quit: bool,
+    #[allow(dead_code)]
     pub process_list_state: ListState,
     pub last_update: Instant,
     pub show_help: bool,

--- a/tests/kill.rs
+++ b/tests/kill.rs
@@ -82,7 +82,7 @@ mod tests {
     fn test_kill_current_process_protection() {
         // Try to kill the current process (should be protected or handled gracefully)
         let current_pid = unsafe { GetCurrentProcessId() };
-        let result = winix::kill::execute(&[&current_pid.to_string()]);
+        let _result = winix::kill::execute(&[&current_pid.to_string()]);
         assert!(true, "Test process should still be running");
     }
 
@@ -236,10 +236,11 @@ mod tests {
         thread::sleep(Duration::from_millis(100));
 
         // Test -s flag with different signals
+        let pid_str = pid.to_string();
         let test_cases = vec![
-            vec!["-s", "TERM", &pid.to_string()],
-            vec!["-s", "9", &pid.to_string()],
-            vec!["-s", "KILL", &pid.to_string()],
+            vec!["-s", "TERM", &pid_str],
+            vec!["-s", "9", &pid_str],
+            vec!["-s", "KILL", &pid_str],
         ];
 
         for args in test_cases {
@@ -254,8 +255,9 @@ mod tests {
             let new_pid = new_child.id();
             thread::sleep(Duration::from_millis(100));
 
+            let new_pid_str = new_pid.to_string();
             let mut test_args = args.clone();
-            test_args[2] = &new_pid.to_string();
+            test_args[2] = &new_pid_str;
 
             let result = winix::kill::execute(&test_args);
             assert!(result.is_ok(), "Kill with -s flag should succeed for args: {:?}", test_args);
@@ -557,7 +559,7 @@ mod tests {
             .spawn()
             .expect("Failed to start ping process");
 
-        let pid = child.id();
+        let _pid = child.id();
         thread::sleep(Duration::from_millis(100));
 
         // Test that signal names are case-insensitive

--- a/tests/kill.rs
+++ b/tests/kill.rs
@@ -96,11 +96,493 @@ mod tests {
         let result = winix::kill::execute(&["not_a_number"]);
         assert!(result.is_err(), "Kill with invalid PID should fail");
 
-        // Test with negative PID
+        // Test with negative PID (should be treated as invalid signal)
         let result = winix::kill::execute(&["-123"]);
-        // This might be treated as a signal, so check implementation behavior
-        // For now, just ensure it doesn't panic
+        assert!(result.is_err(), "Kill with invalid signal should fail");
+    }
+
+    #[test]
+    fn test_kill_by_process_name() {
+        // Start multiple processes with the same name
+        let mut children = Vec::new();
+        for _ in 0..2 {
+            let child = Command::new("ping")
+                .args(&["127.0.0.1", "-n", "1000"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start ping process");
+            children.push(child);
+        }
+
+        thread::sleep(Duration::from_millis(100));
+
+        // Kill by process name (should kill only one by default)
+        let result = winix::kill::execute(&["ping"]);
+        
+        // Note: This test will fail until process name killing is implemented
+        // For now, we just check that it doesn't panic
         let _ = result;
+
+        // Clean up remaining processes
+        for mut child in children {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn test_kill_all_processes_by_name() {
+        // Start multiple processes with the same name
+        let mut children = Vec::new();
+        for _ in 0..3 {
+            let child = Command::new("ping")
+                .args(&["127.0.0.1", "-n", "1000"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start ping process");
+            children.push(child);
+        }
+
+        thread::sleep(Duration::from_millis(100));
+
+        // Kill all processes with name using -a flag
+        let result = winix::kill::execute(&["-a", "ping"]);
+        
+        // Note: This test will fail until process name killing is implemented
+        let _ = result;
+
+        // Clean up any remaining processes
+        for mut child in children {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn test_kill_with_valid_signals() {
+        let test_signals = vec![
+            ("-2", "SIGINT"),
+            ("-3", "SIGQUIT"), 
+            ("-9", "SIGKILL"),
+            ("-15", "SIGTERM"),
+            ("-INT", "INT signal"),
+            ("-QUIT", "QUIT signal"),
+            ("-KILL", "KILL signal"),
+            ("-TERM", "TERM signal"),
+        ];
+
+        for (signal, description) in test_signals {
+            let mut child = Command::new("ping")
+                .args(&["127.0.0.1", "-n", "1000"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start ping process");
+
+            let pid = child.id();
+            thread::sleep(Duration::from_millis(100));
+
+            let result = winix::kill::execute(&[signal, &pid.to_string()]);
+            
+            // Should succeed for all valid signals
+            assert!(result.is_ok(), "Kill with {} ({}) should succeed", signal, description);
+            
+            thread::sleep(Duration::from_millis(200));
+            
+            // Clean up if process is still running
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn test_kill_with_invalid_signals() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        let invalid_signals = vec![
+            "-HUP",     // Not supported on Windows
+            "-USR1",    // Not supported on Windows
+            "-PIPE",    // Not supported on Windows
+            "-999",     // Invalid signal number
+            "-INVALID", // Invalid signal name
+        ];
+
+        for signal in invalid_signals {
+            let result = winix::kill::execute(&[signal, &pid.to_string()]);
+            assert!(result.is_err(), "Kill with invalid signal {} should fail", signal);
+        }
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_kill_with_explicit_signal_flag() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test -s flag with different signals
+        let test_cases = vec![
+            vec!["-s", "TERM", &pid.to_string()],
+            vec!["-s", "9", &pid.to_string()],
+            vec!["-s", "KILL", &pid.to_string()],
+        ];
+
+        for args in test_cases {
+            // Start a new process for each test
+            let mut new_child = Command::new("ping")
+                .args(&["127.0.0.1", "-n", "1000"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start ping process");
+
+            let new_pid = new_child.id();
+            thread::sleep(Duration::from_millis(100));
+
+            let mut test_args = args.clone();
+            test_args[2] = &new_pid.to_string();
+
+            let result = winix::kill::execute(&test_args);
+            assert!(result.is_ok(), "Kill with -s flag should succeed for args: {:?}", test_args);
+
+            thread::sleep(Duration::from_millis(200));
+            let _ = new_child.kill();
+        }
+
+        // Clean up original process
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_print_only_mode() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test -p flag (print only, don't kill)
+        let result = winix::kill::execute(&["-p", &pid.to_string()]);
+        assert!(result.is_ok(), "Print-only mode should succeed");
+
+        thread::sleep(Duration::from_millis(200));
+
+        // Process should still be running after -p
+        assert!(is_process_running(pid), "Process should still be running after -p flag");
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_print_only_with_process_name() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        thread::sleep(Duration::from_millis(100));
+
+        // Test -p flag with process name
+        let result = winix::kill::execute(&["-p", "ping"]);
+        
+        // Should succeed but not kill the process
+        // Note: Will fail until process name lookup is implemented
+        let _ = result;
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_conflicting_signal_options() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test conflicting signal specifications (should fail)
+        let result = winix::kill::execute(&["-9", "-s", "TERM", &pid.to_string()]);
+        assert!(result.is_err(), "Conflicting signal options should fail");
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_queue_value_option() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test -q flag with value
+        let result = winix::kill::execute(&["-q", "42", "-TERM", &pid.to_string()]);
+        assert!(result.is_ok(), "Kill with queue value should succeed");
+
+        thread::sleep(Duration::from_millis(200));
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_end_of_options_marker() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test -- marker (everything after is treated as target)
+        let result = winix::kill::execute(&["--", &pid.to_string()]);
+        assert!(result.is_ok(), "Kill with -- marker should succeed");
+
+        thread::sleep(Duration::from_millis(200));
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_multiple_targets() {
+        // Start multiple processes
+        let mut children = Vec::new();
+        let mut pids = Vec::new();
+
+        for _ in 0..3 {
+            let child = Command::new("ping")
+                .args(&["127.0.0.1", "-n", "1000"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start ping process");
+            
+            pids.push(child.id().to_string());
+            children.push(child);
+        }
+
+        thread::sleep(Duration::from_millis(100));
+
+        // Kill multiple processes at once
+        let mut args = vec!["-9"];
+        for pid in &pids {
+            args.push(pid);
+        }
+
+        let result = winix::kill::execute(&args);
+        assert!(result.is_ok(), "Kill with multiple targets should succeed");
+
+        thread::sleep(Duration::from_millis(500));
+
+        // Clean up any remaining processes
+        for mut child in children {
+            let _ = child.kill();
+        }
+    }
+
+    #[test]
+    fn test_timeout_option() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test --timeout option
+        let result = winix::kill::execute(&["--timeout", "1000", "KILL", &pid.to_string()]);
+        
+        // Should succeed (even if not fully implemented yet)
+        assert!(result.is_ok(), "Kill with timeout should succeed");
+
+        thread::sleep(Duration::from_millis(200));
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_invalid_a_flag_with_pid() {
+        // Test that -a flag fails when used with numeric PID
+        let result = winix::kill::execute(&["-a", "1234"]);
+        assert!(result.is_err(), "-a flag with numeric PID should fail");
+    }
+
+    #[test]
+    fn test_missing_signal_argument() {
+        // Test missing argument for -s flag
+        let result = winix::kill::execute(&["-s"]);
+        assert!(result.is_err(), "Missing signal argument should fail");
+
+        // Test missing argument for -q flag
+        let result = winix::kill::execute(&["-q"]);
+        assert!(result.is_err(), "Missing queue value argument should fail");
+    }
+
+    #[test]
+    fn test_system_process_protection() {
+        // Test protection against killing system processes
+        let system_pids = vec!["0", "4", "8"]; // Common system process PIDs
+        
+        for pid in system_pids {
+            let result = winix::kill::execute(&[pid]);
+            // Should either fail gracefully or be protected
+            // Implementation dependent - just ensure no panic
+            let _ = result;
+        }
+    }
+
+    #[test]
+    fn test_nonexistent_process_name() {
+        // Test killing a process name that doesn't exist
+        let result = winix::kill::execute(&["nonexistent_process_name_12345"]);
+        assert!(result.is_err(), "Killing nonexistent process name should fail");
+    }
+
+    #[test]
+    fn test_combined_flags() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test combining valid flags
+        let result = winix::kill::execute(&["-q", "42", "-s", "TERM", &pid.to_string()]);
+        assert!(result.is_ok(), "Combined valid flags should succeed");
+
+        thread::sleep(Duration::from_millis(200));
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_invalid_queue_value() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test invalid queue value (non-numeric)
+        let result = winix::kill::execute(&["-q", "invalid", &pid.to_string()]);
+        assert!(result.is_err(), "Invalid queue value should fail");
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_timeout_without_signal() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test --timeout without specifying the final signal (should fail)
+        let result = winix::kill::execute(&["--timeout", "1000", &pid.to_string()]);
+        assert!(result.is_err(), "Timeout without signal should fail");
+
+        // Clean up
+        let _ = child.kill();
+    }
+
+    #[test]
+    fn test_print_only_no_targets() {
+        // Test -p flag without any targets (should be allowed)
+        let result = winix::kill::execute(&["-p"]);
+        // This should be OK according to Unix kill behavior
+        let _ = result; // Implementation dependent
+    }
+
+    #[test]
+    fn test_case_insensitive_signals() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+
+        // Test that signal names are case-insensitive
+        let signals = vec!["-term", "-TERM", "-Term", "-kill", "-KILL", "-Kill"];
+        
+        for signal in signals {
+            let mut new_child = Command::new("ping")
+                .args(&["127.0.0.1", "-n", "1000"])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("Failed to start ping process");
+
+            let new_pid = new_child.id();
+            thread::sleep(Duration::from_millis(50));
+
+            let result = winix::kill::execute(&[signal, &new_pid.to_string()]);
+            assert!(result.is_ok(), "Case-insensitive signal {} should work", signal);
+
+            thread::sleep(Duration::from_millis(100));
+            let _ = new_child.kill();
+        }
+
+        // Clean up original
+        let _ = child.kill();
     }
 
     // Helper function to check if a process is running

--- a/tests/kill.rs
+++ b/tests/kill.rs
@@ -1,0 +1,118 @@
+#[cfg(windows)]
+mod tests {
+    use std::process::{Command, Stdio};
+    use std::thread;
+    use std::time::Duration;
+    
+    use winapi::um::processthreadsapi::{GetCurrentProcessId, OpenProcess};
+    use winapi::um::winnt::PROCESS_QUERY_INFORMATION;
+    use winapi::um::synchapi::WaitForSingleObject;
+    use winapi::um::handleapi::CloseHandle;
+
+    #[test]
+    fn test_kill_running_process() {
+        // Starting a long-running process
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"]) // Ping localhost 1000 times
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+        assert!(is_process_running(pid), "Process should be running before kill");
+
+        //Call to kill function as in UNIX
+        let result = winix::kill::execute(&[&pid.to_string()]);
+
+        assert!(result.is_ok(), "Kill command should succeed");
+        thread::sleep(Duration::from_millis(500));
+
+        // Verify the process was actually killed
+        match child.try_wait() {
+            Ok(Some(_)) => {
+                assert!(true, "Process was successfully terminated");
+            }
+            Ok(None) => {
+                //kill failed
+                let _ = child.kill(); // Clean up the started process
+                panic!("Process is still running after kill command");
+            }
+            Err(e) => {
+                panic!("Error checking process status: {}", e);
+            }
+        }
+    }
+
+    #[test]
+    fn test_kill_nonexistent_process() {
+        let fake_pid = "999999"; //Fake pid unlikely to exist
+        let result = winix::kill::execute(&[fake_pid]);
+        // This should return an error
+        assert!(result.is_err(), "Kill should fail for non-existent process");
+    }
+
+    #[test]
+    fn test_kill_with_signal() {
+        let mut child = Command::new("ping")
+            .args(&["127.0.0.1", "-n", "1000"])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("Failed to start ping process");
+
+        let pid = child.id();
+        thread::sleep(Duration::from_millis(100));
+        let result = winix::kill::execute(&["-9", &pid.to_string()]);
+        assert!(result.is_ok(), "Kill with signal should succeed");
+        thread::sleep(Duration::from_millis(500));
+        
+        match child.try_wait() {
+            Ok(Some(_)) => assert!(true, "Process terminated with signal"),
+            Ok(None) => {
+                let _ = child.kill();
+                panic!("Process still running after kill -9");
+            }
+            Err(e) => panic!("Error checking process: {}", e),
+        }
+    }
+
+    #[test]
+    fn test_kill_current_process_protection() {
+        // Try to kill the current process (should be protected or handled gracefully)
+        let current_pid = unsafe { GetCurrentProcessId() };
+        let result = winix::kill::execute(&[&current_pid.to_string()]);
+        assert!(true, "Test process should still be running");
+    }
+
+    #[test]
+    fn test_kill_invalid_arguments() {
+        // Test with no arguments
+        let result = winix::kill::execute(&[]);
+        assert!(result.is_err(), "Kill with no args should fail");
+
+        // Test with invalid PID format
+        let result = winix::kill::execute(&["not_a_number"]);
+        assert!(result.is_err(), "Kill with invalid PID should fail");
+
+        // Test with negative PID
+        let result = winix::kill::execute(&["-123"]);
+        // This might be treated as a signal, so check implementation behavior
+        // For now, just ensure it doesn't panic
+        let _ = result;
+    }
+
+    // Helper function to check if a process is running
+    fn is_process_running(pid: u32) -> bool {
+        unsafe {
+            let handle = OpenProcess(PROCESS_QUERY_INFORMATION, 0, pid);
+            if handle.is_null() {
+                return false;
+            }
+            let result = WaitForSingleObject(handle, 0);
+            CloseHandle(handle);
+            result == 0x102
+        }
+    }
+}


### PR DESCRIPTION
Key changes made
- Added src/kill.rs, exact implementation is covered in the file's header, which explains all details.
- Added test/kill.rs which has around 26 different tests to check for various possibilities, edge cases and options usable. 

Minor changes 
- Added tags to other codes to supress compile warnings

Things not adresses
- TUI implementation is non trivial and suggested for comlete TUI revamp
