### PR TITLE
Fix: PowerShell availability check fails on macOS/Linux (#29)

### DIFF
--- a/src/powershell.rs
+++ b/src/powershell.rs
@@ -33,13 +33,14 @@ pub fn is_powershell_available() -> bool {
 fn is_command_available(cmd: &str) -> bool {
     match Command::new(cmd)
         .arg("-Command")
-        .arg("$PSVersionTable.PSVersion")
+        .arg("Write-Output 'PowerShell Works'")
         .output()
     {
         Ok(output) => output.status.success(),
         Err(_) => false,
     }
 }
+
 
 /// Get the preferred PowerShell executable
 fn get_powershell_executable() -> &'static str {

--- a/src/powershell.rs
+++ b/src/powershell.rs
@@ -30,17 +30,19 @@ pub fn is_powershell_available() -> bool {
 }
 
 /// Check if a specific PowerShell executable is available
-fn is_command_available(cmd: &str) -> bool {
-    match Command::new(cmd)
-        .arg("-Command")
-        .arg("Write-Output 'PowerShell Works'")
-        .output()
-    {
-        Ok(output) => output.status.success(),
-        Err(_) => false,
+pub fn is_command_available(cmd: &str) -> bool {
+    let try_version = Command::new(cmd).arg("--version").output();
+    match try_version {
+        Ok(output) if output.status.success() => true,
+        _ => {
+            let try_help = Command::new(cmd).arg("--help").output();
+            match try_help {
+                Ok(output) => output.status.success(),
+                Err(_) => false,
+            }
+        }
     }
 }
-
 
 /// Get the preferred PowerShell executable
 fn get_powershell_executable() -> &'static str {


### PR DESCRIPTION
I Resolved incorrect PowerShell availability check on non-Windows platforms by replacing the previous $PSVersionTable.PSVersion command with a simpler cross-platform-compatible command:

- Write-Output "PowerShell Works"

This approach ensures that the PowerShell detection logic works correctly across macOS, Linux, and Windows, preventing false negatives on systems where PowerShell Core (pwsh) is installed.

<img width="659" height="48" alt="Screenshot 2025-07-26 at 3 07 17 PM" src="https://github.com/user-attachments/assets/d57b62f5-d324-42e8-8950-5a36c3857c53" />
