### PR TITLE
feat: Add echo and touch command with cross-platform support (#20)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 default-run = "winix"
 
 [dependencies]
+which = "5"
 colored = "3.0.0"
 ratatui = { version = "0.29.0", features = ["all-widgets"] }
 crossterm = "0.28.1"

--- a/src/echo.rs
+++ b/src/echo.rs
@@ -1,0 +1,8 @@
+use std::io::{self, Write};
+
+pub fn run(args: &[String]) {
+    print!("{}", args.join(" "));
+    io::stdout().flush().unwrap();
+}
+
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,29 @@ fn command_loop() {
 
             "echo" => echo::run(&command_args),
             "touch" => touch::run(&command_args),
+
+
+            // "echo" => {
+            //     if !command_args.is_empty() {
+            //         println!("{}", command_args.join(" "));
+            //     } else {
+            //         println!(); // print a blank line if no arguments
+            //     }
+            // }
+        
+            // "touch" => {
+            //     for file in &command_args {
+            //         match std::fs::OpenOptions::new()
+            //             .create(true)
+            //             .write(true)
+            //             .append(true)
+            //             .open(file)
+            //         {
+            //             Ok(_) => {}
+            //             Err(e) => eprintln!("touch: cannot create file '{}': {}", file, e),
+            //         }
+            //     }
+            // }
             "uname" => uname::execute(),
             "ps" => ps::execute(),
             "sensors" => sensors::execute(),
@@ -325,3 +348,4 @@ fn ls_command(path: &str) -> std::io::Result<()> {
     }
     Ok(())
 }
+

--- a/src/powershell.rs
+++ b/src/powershell.rs
@@ -33,13 +33,14 @@ pub fn is_powershell_available() -> bool {
 fn is_command_available(cmd: &str) -> bool {
     match Command::new(cmd)
         .arg("-Command")
-        .arg("$PSVersionTable.PSVersion")
+        .arg("Write-Output 'PowerShell Works'")
         .output()
     {
         Ok(output) => output.status.success(),
         Err(_) => false,
     }
 }
+
 
 /// Get the preferred PowerShell executable
 fn get_powershell_executable() -> &'static str {

--- a/src/powershell.rs
+++ b/src/powershell.rs
@@ -30,17 +30,19 @@ pub fn is_powershell_available() -> bool {
 }
 
 /// Check if a specific PowerShell executable is available
-fn is_command_available(cmd: &str) -> bool {
-    match Command::new(cmd)
-        .arg("-Command")
-        .arg("Write-Output 'PowerShell Works'")
-        .output()
-    {
-        Ok(output) => output.status.success(),
-        Err(_) => false,
+pub fn is_command_available(cmd: &str) -> bool {
+    let try_version = Command::new(cmd).arg("--version").output();
+    match try_version {
+        Ok(output) if output.status.success() => true,
+        _ => {
+            let try_help = Command::new(cmd).arg("--help").output();
+            match try_help {
+                Ok(output) => output.status.success(),
+                Err(_) => false,
+            }
+        }
     }
 }
-
 
 /// Get the preferred PowerShell executable
 fn get_powershell_executable() -> &'static str {

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,0 +1,44 @@
+use std::fs::{OpenOptions, File};
+use std::path::Path;
+use std::io::Write;
+
+#[cfg(unix)]
+use filetime::{FileTime, set_file_times};
+
+pub fn run(args: &[String]) {
+    for file_name in args {
+        let path = Path::new(file_name);
+
+        // If the file doesn't exist, create it
+        if !path.exists() {
+            match File::create(&path) {
+                Ok(_) => println!("Created '{}'", file_name),
+                Err(e) => eprintln!("touch: cannot create file '{}': {}", file_name, e),
+            }
+        } else {
+            #[cfg(unix)]
+            {
+                // Update the access and modification times
+                let now = FileTime::now();
+                if let Err(e) = set_file_times(&path, now, now) {
+                    eprintln!("touch: failed to update timestamps for '{}': {}", file_name, e);
+                } else {
+                    println!("Updated timestamp for '{}'", file_name);
+                }
+            }
+
+            #[cfg(windows)]
+            {
+                // On Windows, simulate a timestamp update by opening in append mode
+                match OpenOptions::new().append(true).open(&path) {
+                    Ok(mut file) => {
+                        // Optionally write 0 bytes to trigger timestamp update
+                        let _ = file.write(&[]);
+                        println!("Simulated timestamp update for '{}'", file_name);
+                    },
+                    Err(e) => eprintln!("touch: failed to open file '{}': {}", file_name, e),
+                }
+            }
+        }
+    }
+}

--- a/tests/echo_test.rs
+++ b/tests/echo_test.rs
@@ -1,0 +1,12 @@
+use std::process::Command;
+
+#[test]
+fn test_echo_output() {
+    let output = Command::new("cargo")
+        .args(&["run", "--quiet", "--", "echo", "Hello,", "Rust!"])
+        .output()
+        .expect("Failed to run echo");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Hello, Rust!"));
+}

--- a/tests/touch_test.rs
+++ b/tests/touch_test.rs
@@ -1,0 +1,23 @@
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+#[test]
+fn test_touch_creates_file() {
+    let filename = "test_temp_file.txt";
+
+    // Cleanup before
+    if Path::new(filename).exists() {
+        fs::remove_file(filename).unwrap();
+    }
+
+    let output = Command::new("cargo")
+        .args(&["run", "--quiet", "--", "touch", filename])
+        .output()
+        .expect("Failed to run touch");
+
+    assert!(Path::new(filename).exists(), "File was not created");
+
+    // Cleanup after
+    fs::remove_file(filename).unwrap();
+}


### PR DESCRIPTION
This pull request implements the `echo` and `touch` commands, following Unix-like behavior as closely as possible, with full compatibility across **Windows** and **macOS** platforms.

### Implemented

- `echo`: Prints arguments to standard output.
- `touch`: 
  - Creates files if they do not exist.
  - Updates file modification timestamps.
  - Uses `filetime` crate on Unix-based systems for accurate timestamp updates.
  - Uses fallback append mode on Windows to simulate a touch operation.
  
  Video Link :- https://drive.google.com/file/d/17vjXnk-_G07krTNj7IEPx2O6b6obqzvT/view?usp=sharing
