### PR TITLE
make process.rs cross-platform by isolating Windows-specific code(resolves #18)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1134,7 @@ dependencies = [
  "ratatui",
  "sysinfo",
  "tempfile",
+ "which",
  "winapi",
  "windows-acl",
 ]


### PR DESCRIPTION
This PR resolves a build issue on non-Windows platforms caused by the use of CreateProcessW, winapi, and std::os::windows, which are all specific to Windows.

## Changes Made

- Moved all Windows-specific code into a #[cfg(windows)] mod windows_process block.

- Added a #[cfg(not(windows))] fallback module with a stubbed spawn() function for unsupported platforms.

- Maintained a consistent API across platforms by defining ProcessHandle and ProcessError in both implementations.
