### PR TITLE
remove unrechable kill

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +821,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix 0.38.44",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "widestring"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1112,6 +1134,7 @@ dependencies = [
  "ratatui",
  "sysinfo",
  "tempfile",
+ "which",
  "winapi",
  "windows-acl",
 ]

--- a/src/main.rs
+++ b/src/main.rs
@@ -254,31 +254,6 @@ fn command_loop() {
                     }
                 }
             }
-            "kill" => {
-                if parts.len() < 2 {
-                    println!("{}", "Usage: kill [-signal|-s signal|-p] [-q value] [-a] [--timeout milliseconds signal] [--] pid|name...".red());
-                    println!();
-                    println!("{}", "Supported Windows signals:".yellow());
-                    println!("  {}", "-2, -INT    Interrupt (Ctrl+C)".dimmed());
-                    println!("  {}", "-3, -QUIT   Quit (Ctrl+Break)".dimmed());
-                    println!("  {}", "-9, -KILL   Force terminate (default)".dimmed());
-                    println!("  {}", "-15, -TERM  Graceful terminate".dimmed());
-                    println!();
-                    println!("{}", "Examples:".yellow());
-                    println!("  {}", "kill 1234".dimmed());
-                    println!("  {}", "kill -TERM 1234".dimmed());
-                    println!("  {}", "kill -9 1234".dimmed());
-                    println!("  {}", "kill -a notepad".dimmed());
-                } else {
-                    // Pass all arguments except the command itself
-                    let args: Vec<&str> = parts[1..].to_vec();
-                    #[cfg(windows)]
-                    match kill::execute(&args) {
-                        Ok(_) => {}
-                        Err(e) => println!("{}", format!("kill: {}", e).red()),
-                    }
-                }
-            }
             "psh" | "powershell" => {
                 if parts.len() == 1 {
                     powershell::execute(&[]);


### PR DESCRIPTION
Resolved a logic bug where "kill" command was matched twice in the same match block, making the second arm unreachable. Combined/removed redundant logic to ensure single, clean match case for "kill".