### PR TITLE
fix(touch.rs) issues

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,7 @@ mod rm;
 fn main() {
 
     let args: Vec<String> = env::args().collect();
+    
     if args.len() > 1 && args[1] == "--cli" {
         // Run original command-line mode (optional fallback)
         show_splash_screen();
@@ -161,7 +162,7 @@ fn command_loop() {
                 );
                 break;
             }
-
+         
             #[cfg(windows)]
             "chmod" => {
                 if parts.len() < 2 {

--- a/src/touch.rs
+++ b/src/touch.rs
@@ -1,4 +1,5 @@
-use std::fs::{File};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
 use std::path::Path;
 
 #[cfg(unix)]

--- a/tests/touch_test.rs
+++ b/tests/touch_test.rs
@@ -11,11 +11,22 @@ fn test_touch_creates_file() {
         fs::remove_file(filename).unwrap();
     }
 
+    // Run the binary with filename as argument
     let output = Command::new("cargo")
-        .args(&["run", "--quiet", "--", "touch", filename])
+        .args(&["run", "--quiet", "--", filename])
         .output()
         .expect("Failed to run touch");
 
+    // Debug output in case of error
+    if !output.status.success() {
+        eprintln!(
+            "STDOUT: {}\nSTDERR: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    // Check file exists
     assert!(Path::new(filename).exists(), "File was not created");
 
     // Cleanup after


### PR DESCRIPTION
As shown in the screenshot, the following compile-time error occurred:
`error[E0433]: failed to resolve: use of undeclared type OpenOptions`

This happened because `OpenOptions` was used without being explicitly imported in `touch.rs`.
