### PR TITLE
feat(windows): add Job Object API with create() and assign(pid)

### DIFF
--- a/src/commands/job.rs
+++ b/src/commands/job.rs
@@ -1,0 +1,92 @@
+#![allow(non_snake_case)]
+use std::io;
+use std::ptr;
+use std::ffi::OsStr;
+use std::iter::once;
+use std::os::windows::ffi::OsStrExt;
+
+#[cfg(target_os = "windows")]
+use winapi::um::jobapi2::{CreateJobObjectW, AssignProcessToJobObject, TerminateJobObject};
+#[cfg(target_os = "windows")]
+use winapi::um::processthreadsapi::OpenProcess;
+#[cfg(target_os = "windows")]
+use winapi::um::handleapi::CloseHandle;
+#[cfg(target_os = "windows")]
+use winapi::um::winnt::PROCESS_ALL_ACCESS;
+#[cfg(target_os = "windows")]
+use winapi::shared::minwindef::FALSE;
+#[cfg(target_os = "windows")]
+use winapi::shared::ntdef::NULL;
+
+#[cfg(target_os = "windows")]
+pub struct Job {
+    handle: winapi::shared::ntdef::HANDLE,
+}
+
+#[cfg(target_os = "windows")]
+impl Job {
+    /// Create a new unnamed Job object.
+    pub fn create() -> io::Result<Self> {
+        // CreateJobObjectW(LPSECURITY_ATTRIBUTES lpJobAttributes, LPCWSTR lpName)
+        // Use a null name for unnamed job
+        unsafe {
+            // pass null ptrs for security attributes and name
+            let handle = CreateJobObjectW(ptr::null_mut(), ptr::null());
+
+            if handle.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+
+            Ok(Job { handle })
+        }
+    }
+
+    /// Assign an existing process (by PID) to this Job.
+    pub fn assign(&self, pid: u32) -> io::Result<()> {
+        unsafe {
+            // Open process with full access (simplest)
+            let process_handle = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
+            if process_handle.is_null() {
+                return Err(io::Error::last_os_error());
+            }
+
+            let result = AssignProcessToJobObject(self.handle, process_handle);
+            // Close process handle regardless
+            CloseHandle(process_handle);
+
+            if result == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+
+    /// Terminate all processes associated with this job object.
+    /// Useful for tests: kills children assigned to job.
+    pub fn terminate(&self, exit_code: u32) -> io::Result<()> {
+        unsafe {
+            let result = TerminateJobObject(self.handle, exit_code);
+            if result == 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        }
+    }
+
+    /// Return the raw handle (if needed elsewhere). Use carefully.
+    pub fn raw_handle(&self) -> winapi::shared::ntdef::HANDLE {
+        self.handle
+    }
+}
+
+#[cfg(target_os = "windows")]
+impl Drop for Job {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.handle.is_null() {
+                CloseHandle(self.handle);
+                self.handle = ptr::null_mut();
+            }
+        }
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -41,6 +41,8 @@ pub mod uname;
 pub mod uptime;
 #[cfg(windows)]
 pub mod kill;
+#[cfg(target_os = "windows")]
+pub mod job;
 
 // src/command/mod.rs
 pub fn dummy() {

--- a/tests/job_test.rs
+++ b/tests/job_test.rs
@@ -1,0 +1,65 @@
+#![cfg(target_os = "windows")]
+
+use std::process::{Command, Stdio};
+use std::thread::sleep;
+use std::time::Duration;
+use winix::job::Job;
+
+fn spawn_sleep_process() -> std::process::Child {
+    // Use PowerShell's Start-Sleep for a lightweight long-running child
+    Command::new("powershell")
+        .args(&["-Command", "Start-Sleep -Seconds 30"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null())
+        .spawn()
+        .expect("Failed to spawn sleep process")
+}
+
+#[test]
+fn test_create_and_assign_process_to_job_and_terminate() {
+    // Create job
+    let job = Job::create().expect("Failed to create Job");
+
+    // Spawn a child process
+    let mut child = spawn_sleep_process();
+    let pid = child.id();
+    println!("Spawned child PID: {}", pid);
+
+    // Assign child to job
+    job.assign(pid).expect("Failed to assign process to job");
+
+    // Give OS a moment
+    sleep(Duration::from_millis(100));
+
+    // Terminate all processes in job. This should kill the child.
+    job.terminate(1).expect("Failed to terminate job");
+
+    // Wait briefly and check child
+    sleep(Duration::from_millis(200));
+
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            // Child has exited; success
+            println!("Child exited with status: {:?}", status);
+            assert!(true);
+        }
+        Ok(None) => {
+            // Still running -> fail and attempt cleanup
+            let _ = child.kill();
+            panic!("Child still running after TerminateJobObject");
+        }
+        Err(e) => {
+            panic!("Error checking child process: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_assign_invalid_pid_fails() {
+    let job = Job::create().expect("Failed to create Job");
+    // Use an unlikely PID value
+    let bad_pid: u32 = 999_999_999;
+    let res = job.assign(bad_pid);
+    assert!(res.is_err(), "Expected assigning invalid PID to fail");
+}


### PR DESCRIPTION
### Summary
Implements Windows Job Objects integration.

- Expose `Job::create()` for creating a job object.
- Expose `Job::assign(pid)` to assign processes to the job.
- Added integration test simulating child process group assignment.

### Testing
- Verified compilation on Windows.
- Ubuntu fallback tested (compiles but skips Windows-specific code).
